### PR TITLE
FIX: Restore support for docs plugin

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -212,3 +212,10 @@ a.d-toc-close {
     content: "#{$composer_toc_text}";
   }
 }
+
+// Docs plugin outlet
+.below-docs-topic-outlet.d-toc-wrapper {
+  position: sticky;
+  top: calc(var(--header-offset, 60px) + 1em);
+  max-height: calc(100vh - 2em - var(--header-offset, 60px));
+}

--- a/javascripts/discourse/connectors/below-docs-topic/d-toc-wrapper.hbs
+++ b/javascripts/discourse/connectors/below-docs-topic/d-toc-wrapper.hbs
@@ -1,0 +1,1 @@
+{{!-- Docs TOC placeholder --}}

--- a/javascripts/discourse/initializers/disco-toc-main.js
+++ b/javascripts/discourse/initializers/disco-toc-main.js
@@ -76,52 +76,16 @@ export default {
         }
       });
 
+      api.onAppEvent("docs-topic:current-post-scrolled", () => {
+        this.updateTOCSidebar();
+      });
+
       api.onAppEvent("topic:current-post-scrolled", (args) => {
         if (args.postIndex !== 1) {
           return;
         }
 
-        if (!document.querySelector(".d-toc-cooked")) {
-          return;
-        }
-
-        const headings = document.querySelectorAll(".d-toc-post-heading");
-        let closestHeadingDistance = null;
-        let closestHeading = null;
-
-        headings.forEach((heading) => {
-          const distance = Math.abs(
-            domUtils.offset(heading).top - headerOffset() - window.scrollY
-          );
-          if (
-            closestHeadingDistance == null ||
-            distance < closestHeadingDistance
-          ) {
-            closestHeadingDistance = distance;
-            closestHeading = heading;
-          } else {
-            return false;
-          }
-        });
-
-        if (closestHeading) {
-          document.querySelectorAll("#d-toc li").forEach((listItem) => {
-            listItem.classList.remove("active");
-            listItem.classList.remove("direct-active");
-          });
-
-          const anchor = document.querySelector(
-            `#d-toc a[data-d-toc="${closestHeading.getAttribute("id")}"]`
-          );
-
-          if (!anchor) {
-            return;
-          }
-          anchor.parentElement.classList.add("direct-active");
-          parentsUntil(anchor, "#d-toc", ".d-toc-item").forEach((liParent) => {
-            liParent.classList.add("active");
-          });
-        }
+        this.updateTOCSidebar();
       });
 
       api.cleanupStream(() => {
@@ -129,6 +93,47 @@ export default {
         document.removeEventListener("click", this.clickTOC, false);
       });
     });
+  },
+
+  updateTOCSidebar() {
+    if (!document.querySelector(".d-toc-cooked")) {
+      return;
+    }
+
+    const headings = document.querySelectorAll(".d-toc-post-heading");
+    let closestHeadingDistance = null;
+    let closestHeading = null;
+
+    headings.forEach((heading) => {
+      const distance = Math.abs(
+        domUtils.offset(heading).top - headerOffset() - window.scrollY
+      );
+      if (closestHeadingDistance == null || distance < closestHeadingDistance) {
+        closestHeadingDistance = distance;
+        closestHeading = heading;
+      } else {
+        return false;
+      }
+    });
+
+    if (closestHeading) {
+      document.querySelectorAll("#d-toc li").forEach((listItem) => {
+        listItem.classList.remove("active");
+        listItem.classList.remove("direct-active");
+      });
+
+      const anchor = document.querySelector(
+        `#d-toc a[data-d-toc="${closestHeading.getAttribute("id")}"]`
+      );
+
+      if (!anchor) {
+        return;
+      }
+      anchor.parentElement.classList.add("direct-active");
+      parentsUntil(anchor, "#d-toc", ".d-toc-item").forEach((liParent) => {
+        liParent.classList.add("active");
+      });
+    }
   },
 
   insertTOC(headings) {


### PR DESCRIPTION
The refactor in https://github.com/discourse/DiscoTOC/commit/20366c671dc951c2cbca86b119b2008e1e9831d3 inadvertently removed support in Docs (because Docs uses a special template for the topic that doesn't use core's post stream events.) 

Accompanies https://github.com/discourse/discourse-docs/pull/75. 