### PR TITLE
UX: Keep core's top margin for first item in OP

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -178,6 +178,12 @@ a.d-toc-close {
   }
 }
 
+// core sets first child's top margin to 0
+// ensure it's also 0 when TOC markup is first
+.cooked > div[data-theme-toc]:first-child + * {
+  margin-top: 0px;
+}
+
 // RTL Support
 .rtl {
   .d-toc-main {


### PR DESCRIPTION
Context: https://meta.discourse.org/t/discotoc-automatic-table-of-contents/111143/327?u=pmusaraj 