### PR TITLE
UX: Fix layout issues in < 1035px wide windows (take 2)

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -181,6 +181,10 @@ a.d-toc-close {
   .container.posts .topic-navigation.with-topic-progress {
     align-self: start;
   }
+
+  #post_1 .topic-body {
+    float: none;
+  }
 }
 
 // core sets first child's top margin to 0


### PR DESCRIPTION
Should fix most issues. 

Note that this commit might be temporary, @CvX has a PR in core to remove `float:left` for this element in core: https://github.com/discourse/discourse/pull/15693. 