### PR TITLE
UX: Hide TOC on mobile docs topics

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -237,4 +237,7 @@ a.d-toc-close {
   position: sticky;
   top: calc(var(--header-offset, 60px) + 1em);
   max-height: calc(100vh - 2em - var(--header-offset, 60px));
+  .mobile-view & {
+    display: none;
+  }
 }


### PR DESCRIPTION
See https://meta.discourse.org/t/discotoc-mobile-view-does-not-work-with-docs/218329 

Because discourse-docs does not use the topic layout from core, it is missing the topic progress widget entirely. So supporting TOC in docs would need a fair bit of work for which I don't have time at the moment. 

Removing TOC on mobile is better than the current broken layout, though. So let's do this, and eventually we can add mobile TOC support for docs. 