### PR TITLE
FIX: Stop jumping on scroll

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -181,10 +181,6 @@ a.d-toc-close {
   .container.posts .topic-navigation.with-topic-progress {
     align-self: start;
   }
-
-  #post_1 .topic-body {
-    float: none;
-  }
 }
 
 // core sets first child's top margin to 0


### PR DESCRIPTION
We previously added a reset to the topic body layout of the first post to fix some wrapping issues, but looks like a) the reset is no longer necessary and b) it causes jumping on scroll. So let's remove it.