### PR TITLE
FIX: Compatibility with loading slider

### DIFF
--- a/javascripts/discourse/initializers/disco-toc-main.js
+++ b/javascripts/discourse/initializers/disco-toc-main.js
@@ -155,7 +155,6 @@ export default {
     const result = this.buildTOC(Array.from(headings));
     document.querySelector(".d-toc-main").appendChild(result);
     document.addEventListener("click", this.clickTOC, false);
-    document.body.classList.add("d-toc-timeline-visible");
   },
 
   clickTOC(e) {


### PR DESCRIPTION
When the loading slider component is active, the TOC was incorrectly being shown when navigating within the app. For example, when clicking a link to a topic's nth post, its TOC aws being displayed (when it should have only displayed if navigating to the OP).

Note the `d-toc-timeline-visible` class is still used, it is just toggled on/off via the `topic:current-post-changed` event only.