### PR TITLE
FIX: Compatibility with discourse-docs plugin

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -236,4 +236,7 @@ a.d-toc-close {
   .mobile-view & {
     display: none;
   }
+  .d-toc-main {
+    display: block;
+  }
 }

--- a/javascripts/discourse/initializers/disco-toc-main.js
+++ b/javascripts/discourse/initializers/disco-toc-main.js
@@ -159,7 +159,13 @@ export default {
   },
 
   clickTOC(e) {
-    if (!document.body.classList.contains("d-toc-timeline-visible")) {
+    const classNames = ["d-toc-timeline-visible", "archetype-docs-topic"];
+
+    if (
+      !classNames.some((className) =>
+        document.body.classList.contains(className)
+      )
+    ) {
       return;
     }
 


### PR DESCRIPTION
This regressed. Sadly, we can't add tests here ATM because of the intersection between this component and the docs plugin. 