### PR TITLE
FIX: Add # to empty hrefs

### DIFF
--- a/javascripts/discourse/initializers/disco-toc-main.js
+++ b/javascripts/discourse/initializers/disco-toc-main.js
@@ -154,10 +154,10 @@ export default {
     const dToc = document.createElement("div");
     dToc.classList.add("d-toc-main");
     dToc.innerHTML = `<div class="d-toc-icons">
-              <a href="" class="scroll-to-bottom" title="${I18n.t(
+              <a href="#" class="scroll-to-bottom" title="${I18n.t(
                 themePrefix("post_bottom_tooltip")
               )}">${iconHTML("downward")}</a>
-              <a href="" class="d-toc-close">${iconHTML("times")}</a></div>`;
+              <a href="#" class="d-toc-close">${iconHTML("times")}</a></div>`;
 
     const existing = document.querySelector(".d-toc-wrapper .d-toc-main");
     if (existing) {

--- a/javascripts/discourse/initializers/disco-toc-main.js
+++ b/javascripts/discourse/initializers/disco-toc-main.js
@@ -286,7 +286,7 @@ export default {
     li.classList.add("d-toc-item");
     li.classList.add(`d-toc-${clonedNode.tagName.toLowerCase()}`);
 
-    li.innerHTML = `<a data-d-toc="${clonedNode.getAttribute("id")}">${
+    li.innerHTML = `<a href="#" data-d-toc="${clonedNode.getAttribute("id")}">${
       clonedNode.textContent
     }</a>`;
 


### PR DESCRIPTION
Adding `#` to empty link `href`. This should fix a hard to reproduce issue where on click of link, page reloads.