### PR TITLE
FEATURE: new theme setting to disable TOC in posts with less headings.

### DIFF
--- a/javascripts/discourse/initializers/disco-toc-main.js
+++ b/javascripts/discourse/initializers/disco-toc-main.js
@@ -41,7 +41,7 @@ export default {
               ":scope > h1, :scope > h2, :scope > h3, :scope > h4, :scope > h5";
             const headings = el.querySelectorAll(dTocHeadingSelectors);
 
-            if (headings.length < 1) {
+            if (headings.length < settings.TOC_min_heading) {
               return;
             }
 

--- a/settings.yml
+++ b/settings.yml
@@ -20,3 +20,7 @@ auto_TOC_tags:
   type: list
   list_type: tag
   default: ""
+TOC_min_heading:
+  default: 3
+  min: 1
+  max: 10000

--- a/test/acceptance/toc-test.js
+++ b/test/acceptance/toc-test.js
@@ -125,6 +125,7 @@ acceptance("DiscoTOC - with categories", function (needs) {
 
 acceptance("DiscoTOC - non-text headings", function (needs) {
   needs.pretender((server, helper) => {
+    settings.TOC_min_heading = 1;
     const topicResponse = cloneJSON(topicFixtures["/t/280/1.json"]);
     topicResponse.post_stream.posts[0].cooked = `
       <h3 id="toc-h3-span" data-d-toc="toc-h3-span" class="d-toc-post-heading">

--- a/test/acceptance/toc-test.js
+++ b/test/acceptance/toc-test.js
@@ -157,7 +157,8 @@ acceptance("DiscoTOC - setting TOC_min_heading", function (needs) {
     settings.TOC_min_heading = 3;
     const topicResponse = cloneJSON(topicFixtures["/t/280/1.json"]);
     topicResponse.post_stream.posts[0].cooked =
-    '<h1>\n<a name="h1-first-test-edited-1" class="anchor" href="#h1-first-test-edited-1"></a>帖子控制</h1>\nWelcome' + TOC_MARKUP;
+      '<h1>\n<a name="h1-first-test-edited-1" class="anchor" href="#h1-first-test-edited-1"></a>帖子控制</h1>\nWelcome' +
+      TOC_MARKUP;
 
     server.get("/t/280.json", () => helper.response(topicResponse));
     server.get("/t/280/:post_number.json", () =>
@@ -168,6 +169,9 @@ acceptance("DiscoTOC - setting TOC_min_heading", function (needs) {
   test("hiding TOC element", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
-    assert.notOk(exists(".d-toc-timeline-visible .d-toc-main"), "TOC element not visible");
+    assert.notOk(
+      exists(".d-toc-timeline-visible .d-toc-main"),
+      "TOC element not visible"
+    );
   });
 });

--- a/test/acceptance/toc-test.js
+++ b/test/acceptance/toc-test.js
@@ -150,3 +150,23 @@ acceptance("DiscoTOC - non-text headings", function (needs) {
     );
   });
 });
+
+acceptance("DiscoTOC - setting TOC_min_heading", function (needs) {
+  needs.pretender((server, helper) => {
+    settings.TOC_min_heading = 3;
+    const topicResponse = cloneJSON(topicFixtures["/t/280/1.json"]);
+    topicResponse.post_stream.posts[0].cooked =
+      COOKED_WITH_HEADINGS + TOC_MARKUP;
+
+    server.get("/t/280.json", () => helper.response(topicResponse));
+    server.get("/t/280/:post_number.json", () =>
+      helper.response(topicResponse)
+    );
+  });
+
+  test("not adding TOC element", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    assert.not(exists(".d-toc-wrapper #d-toc"), "TOC element not exists");
+  });
+});

--- a/test/acceptance/toc-test.js
+++ b/test/acceptance/toc-test.js
@@ -167,6 +167,6 @@ acceptance("DiscoTOC - setting TOC_min_heading", function (needs) {
   test("not adding TOC element", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
-    assert.not(exists(".d-toc-wrapper #d-toc"), "TOC element not exists");
+    assert.notOk(exists(".d-toc-wrapper #d-toc"), "TOC element not exists");
   });
 });

--- a/test/acceptance/toc-test.js
+++ b/test/acceptance/toc-test.js
@@ -156,7 +156,7 @@ acceptance("DiscoTOC - setting TOC_min_heading", function (needs) {
     settings.TOC_min_heading = 3;
     const topicResponse = cloneJSON(topicFixtures["/t/280/1.json"]);
     topicResponse.post_stream.posts[0].cooked =
-      COOKED_WITH_HEADINGS + TOC_MARKUP;
+    '<h1>\n<a name="h1-first-test-edited-1" class="anchor" href="#h1-first-test-edited-1"></a>帖子控制</h1>\nWelcome' + TOC_MARKUP;
 
     server.get("/t/280.json", () => helper.response(topicResponse));
     server.get("/t/280/:post_number.json", () =>
@@ -164,9 +164,9 @@ acceptance("DiscoTOC - setting TOC_min_heading", function (needs) {
     );
   });
 
-  test("not adding TOC element", async function (assert) {
+  test("hiding TOC element", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
-    assert.notOk(exists(".d-toc-wrapper #d-toc"), "TOC element not exists");
+    assert.notOk(exists(".d-toc-timeline-visible .d-toc-main"), "TOC element not visible");
   });
 });


### PR DESCRIPTION
The theme setting `TOC_min_heading` will decide whether the TOC should display or not based on the number of heading available in the post.