### PR TITLE
UX: fix TOC header in composer preview when creating a topic

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -216,8 +216,8 @@ a.d-toc-close {
 .edit-title .d-editor-preview [data-theme-toc] {
   background: var(--tertiary);
   color: var(--secondary);
-  border-top: 2px solid var(--secondary);
   position: sticky;
+  z-index: 1;
   top: 0;
   height: 30px;
   display: flex;


### PR DESCRIPTION
The TOC header in the composer preview went behind images when scrolling and had a useless transparent (same color as the background) 2px top border that didn't align properly with the rest of the layout.

Before:
![chrome_LiZsG19xar](https://user-images.githubusercontent.com/5654300/224303636-02003c8a-ba14-4431-8a9a-c45761804c2f.gif)

After:
![chrome_ZpIx1lXU9U](https://user-images.githubusercontent.com/5654300/224303811-2d75101e-f021-46d6-b837-2ee473e858b0.gif)
