### PR TITLE
DEV: Convert connector file to use glimmer component

### DIFF
--- a/javascripts/discourse/connectors/after-topic-progress/d-toc-mini.hbs
+++ b/javascripts/discourse/connectors/after-topic-progress/d-toc-mini.hbs
@@ -1,5 +1,5 @@
-{{d-button
+<DButton
   class="btn-primary"
-  action=(action "showTOCOverlay")
-  label=(theme-prefix "table_of_contents")
-}}
+  @action={{this.showTOCOverlay}}
+  @label={{theme-prefix "table_of_contents"}}
+/>

--- a/javascripts/discourse/connectors/after-topic-progress/d-toc-mini.js
+++ b/javascripts/discourse/connectors/after-topic-progress/d-toc-mini.js
@@ -1,7 +1,9 @@
-export default {
-  actions: {
-    showTOCOverlay() {
-      document.querySelector(".d-toc-wrapper").classList.toggle("overlay");
-    },
-  },
-};
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+
+export default class DTocMini extends Component {
+  @action
+  showTOCOverlay() {
+    document.querySelector(".d-toc-wrapper").classList.toggle("overlay");
+  }
+}


### PR DESCRIPTION
Why this change?

We've established internally that this is the better way to do things