### PR TITLE
FIX: Restore wrapper element for d-toc-mini

### DIFF
--- a/javascripts/discourse/connectors/after-topic-progress/d-toc-mini.hbs
+++ b/javascripts/discourse/connectors/after-topic-progress/d-toc-mini.hbs
@@ -1,5 +1,7 @@
-<DButton
-  class="btn-primary"
-  @action={{this.showTOCOverlay}}
-  @label={{theme-prefix "table_of_contents"}}
-/>
+<div class="d-toc-mini">
+  <DButton
+    class="btn-primary"
+    @action={{this.showTOCOverlay}}
+    @label={{theme-prefix "table_of_contents"}}
+  />
+</div>


### PR DESCRIPTION
This was inadvertently removed in 4ae24c6edc9b5c3633a5c3f97f566c9f10abdddc, and led to the UI appearing on all topics