### PR TITLE
FIX: Scroll enough to show topic timeline from down arrow

### DIFF
--- a/javascripts/discourse/initializers/disco-toc-main.js
+++ b/javascripts/discourse/initializers/disco-toc-main.js
@@ -203,13 +203,24 @@ export default {
     if (e.target.closest("a")) {
       // link to first post bottom
       if (e.target.closest("a").classList.contains("scroll-to-bottom")) {
-        const rect = document
-          .querySelector(".d-toc-cooked")
-          .getBoundingClientRect();
+        let rect, topPosition;
+
+        // if there is a second post, just scroll to the top of that post so the topic timeline shows
+        const secondPost = document.querySelector("#post_2");
+        if (secondPost) {
+          rect = secondPost.getBoundingClientRect();
+          topPosition = rect.top + window.scrollY - headerOffset();
+        } else {
+          // otherwise just go to the bottom of the first post
+          rect = document
+            .querySelector(".d-toc-cooked")
+            .getBoundingClientRect();
+          topPosition = rect.bottom + window.scrollY - headerOffset() - 10;
+        }
 
         if (rect) {
           window.scrollTo({
-            top: rect.bottom + window.scrollY - headerOffset() - 10,
+            top: topPosition,
             behavior: "smooth",
           });
 


### PR DESCRIPTION
This fixes the problem where if you clicked the down / scroll
to bottom arrow at the top of the table of contents, the scroll
would _just_ not quite be enough to show the topic timeline,
which would require another mouse scroll.

Now if there is a second post we just scroll directly to the
top of that, which makes the topic timeline show immediately.

![image](https://github.com/discourse/DiscoTOC/assets/920448/a9166aba-c8e7-4dac-877d-4ed90f321566)

