### PR TITLE
DEV: use more specific selector to avoid flaky test

### DIFF
--- a/spec/system/discotoc_progress_user_spec.rb
+++ b/spec/system/discotoc_progress_user_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "DiscoTOC", system: true do
 
     find("#topic-progress").click
 
-    expect(page).to have_no_css(".timeline-toggle")
+    expect(page).to have_no_css(".timeline-fullscreen .timeline-toggle")
   end
 
   it "d-toc-mini is hidden when scrolled past the first post" do


### PR DESCRIPTION
The CSS uses

`.timeline-fullscreen .timeline-toggle { display: none; }`

so in theory it shouldn't be possible for the page to have this element visible! perhaps `.timeline-toggle` wasn't specific enough so let's try to be 1:1 with `.timeline-fullscreen .timeline-toggle`