### PR TITLE
UX: ignore trust level setting for staff accounts

### DIFF
--- a/javascripts/discourse/initializers/disco-toc-composer.js
+++ b/javascripts/discourse/initializers/disco-toc-composer.js
@@ -13,7 +13,7 @@ export default {
 
       const minimumTL = settings.minimum_trust_level_to_create_TOC;
 
-      if (currentUser.trust_level >= minimumTL) {
+      if (currentUser.trust_level >= minimumTL || currentUser.staff) {
         if (!I18n.translations[I18n.currentLocale()].js.composer) {
           I18n.translations[I18n.currentLocale()].js.composer = {};
         }


### PR DESCRIPTION
At the moment, staff is also limited by their trust level, which is contrary to how we usually handle trust levels.

