### PR TITLE
UX: Add missing descriptions for settings and remove dead settings

### DIFF
--- a/about.json
+++ b/about.json
@@ -6,5 +6,8 @@
   "theme_version": "2.1.0",
   "assets": {
     "icons-sprite": "/assets/sprite.svg"
+  },
+  "modifiers": {
+    "svg_icons": ["align-left", "hashtag"]
   }
 }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,5 +8,7 @@ en:
   theme_metadata:
     settings:
       minimum_trust_level_to_create_TOC: The minimum trust level a user must have in order to see the TOC button in the composer
-      auto_TOC_categories: automatically enable TOC on topics in these categories
-      auto_TOC_tags: automatically enable TOC on topics with these tags
+      composer_toc_text: Text that appears at the top of the preview pane of the composer to indicate the topic will have a table of contents
+      auto_TOC_categories: Automatically enable TOC on topics in these categories
+      auto_TOC_tags: Automatically enable TOC on topics with these tags
+      TOC_min_heading: Minimum number of headings in a topic for the table of contents to be shown

--- a/settings.yml
+++ b/settings.yml
@@ -8,10 +8,6 @@ minimum_trust_level_to_create_TOC:
     - 4
 composer_toc_text:
   default: "This topic will contain a table of contents"
-table_of_contents_icon:
-  default: "align-left"
-anchor_icon:
-  default: "hashtag"
 auto_TOC_categories:
   type: list
   list_type: category


### PR DESCRIPTION
This PR adds missing descriptions for the `composer_toc_text` and `TOC_min_heading` settings replaces "dead" settings whose only purpose was to add icons to the SVG sprite with the `svg_icons` modifier in the about.json file.