### PR TITLE
UX: fix MQ mismatch + adjust btn styling

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -158,20 +158,22 @@ html.rtl SELECTOR {
 .d-toc-mini {
   align-self: stretch;
 
-  button {
+  &__button {
+    border-radius: 0;
+    background: var(--secondary);
+    border: 1px solid var(--primary-low);
     height: 100%;
   }
 }
 
 // overlaid timeline (on mobile and narrow screens)
-@include viewport.until(md) {
+@include viewport.until(lg) {
   .topic-navigation {
     &:has(.d-toc-mini) {
-      @include viewport.until(md) {
         position: sticky;
         bottom: calc(env(safe-area-inset-bottom) + var(--composer-height, 0px));
         z-index: z("timeline");
-      }
+
 
       .d-toc-wrapper {
         position: fixed;

--- a/common/common.scss
+++ b/common/common.scss
@@ -170,10 +170,9 @@ html.rtl SELECTOR {
 @include viewport.until(lg) {
   .topic-navigation {
     &:has(.d-toc-mini) {
-        position: sticky;
-        bottom: calc(env(safe-area-inset-bottom) + var(--composer-height, 0px));
-        z-index: z("timeline");
-
+      position: sticky;
+      bottom: calc(env(safe-area-inset-bottom) + var(--composer-height, 0px));
+      z-index: z("timeline");
 
       .d-toc-wrapper {
         position: fixed;

--- a/javascripts/discourse/components/toc-mini.gjs
+++ b/javascripts/discourse/components/toc-mini.gjs
@@ -41,7 +41,7 @@ export default class TocMini extends Component {
     {{#if this.tocProcessor.hasTOC}}
       <span class="d-toc-mini">
         <DButton
-          class="btn-primary"
+          class="d-toc-mini__button"
           @icon="bars-staggered"
           @action={{this.toggleTOCOverlay}}
         />


### PR DESCRIPTION
There was a mismatch between the MQ cutoff for styling and behaviour of the ToC element ([meta report](https://meta.discourse.org/t/opening-toc-on-ipad-in-portrait-causes-toc-to-overlay-text-with-no-background/387532))

This commit:

- fixes that by moving the MQ from `md` to `lg`, which ensures (smaller) tablets will also render correct
- changes the styling of the `d-toc-mini` button by removing the wrong `btn-primary` class and adding the same styling as other buttons in the same mobile-footer element, which contributes to a more coherent feel. 
This will also block theming of regular buttons to take effect, to avoid irregular styling


| BC | AC |
|--------|--------|
| <img width="848" height="1360" alt="CleanShot 2026-03-13 at 10 48 51@2x" src="https://github.com/user-attachments/assets/f7e86b49-0cc5-4f5a-9246-ed12317e6f5a" /> | <img width="848" height="1360" alt="CleanShot 2026-03-13 at 10 48 12@2x" src="https://github.com/user-attachments/assets/4e8cccca-96cf-4618-9b5b-87a4aec3630c" /> | 